### PR TITLE
feat implement subjects cache

### DIFF
--- a/src/bakabot/bot_commands/reactions.py
+++ b/src/bakabot/bot_commands/reactions.py
@@ -6,6 +6,7 @@ import datetime
 import core.predictor as Predictor
 import disnake
 from core.grades.grades import Grades
+from disnake.ext.commands import InteractionBot
 from message_timers import MessageTimer, MessageTimers
 from utils.utils import read_db
 
@@ -16,7 +17,7 @@ class Reactions:
         message: disnake.Message,
         user: disnake.Member,
         emoji: disnake.PartialEmoji,
-        client: disnake.Client,
+        client: InteractionBot,
     ):
         self.message = message
         self.user = user
@@ -28,7 +29,7 @@ class Reactions:
         queryMessagesDatabase = "predictorMessages"
 
         @classmethod
-        async def query(cls, client: disnake.Client):
+        async def query(cls, client: InteractionBot):
             # Deletes some removed messages from the database while the bot was off
             messages = await MessageTimers.query_messages(cls.queryMessagesDatabase, client)
             if messages:
@@ -73,7 +74,7 @@ class Reactions:
         queryMessagesDatabase = "gradesMessages"
 
         @classmethod
-        async def query(cls, client: disnake.Client):
+        async def query(cls, client: InteractionBot):
             # Deletes some removed messages from the database while the bot was off
             messages = await MessageTimers.query_messages_reactions(cls.queryMessagesDatabase, client)
             if messages:
@@ -118,7 +119,7 @@ class Reactions:
                                 return
 
     @staticmethod
-    async def query(client: disnake.Client):
+    async def query(client: InteractionBot):
         for reaction in Reactions.REACTIONS:
             if reaction.queryMessagesDatabase:
                 asyncio.ensure_future(reaction.query(client))

--- a/src/bakabot/constants.py
+++ b/src/bakabot/constants.py
@@ -1,37 +1,6 @@
 SCHOOL_DAYS_IN_WEEK = 5
 NUM_OF_LESSONS_IN_DAY = 13
 
-# TODO: Ideally not have this hardcoded, instead somehow scrape this
-SUBJECTS = {
-    "Aj": "Jazyk anglický",
-    "Bi": "Biologie",
-    "Ch": "Chemie",
-    "Čj": "Český jazyk a literatura",
-    "D": "Dějepis",
-    "Evh": "Estetická výchova - hudební",
-    "Evv": "Estetická výchova - výtvarná",
-    "Fj": "Jazyk francouzský",
-    "Fy": "Fyzika",
-    "Inf": "Informatika a výpočetní technika",
-    "LpBi": "Laboratorní práce z biologie",
-    "LpCh": "Laboratorní práce z chemie",
-    "LpFy": "Laboratorní práce z fyziky",
-    "M": "Matematika",
-    "TH": "Třídnická hodina",
-    "Tv": "Tělesná výchova",
-    "Z": "Zeměpis",
-    "Zsv": "Základy společenských věd",
-}
-
-SUBJECTS_REVERSED: dict[str, str] = {}
-for key, value in zip(SUBJECTS.keys(), SUBJECTS.values()):
-    SUBJECTS_REVERSED.update({value: key})
-
-SUBJECTS_LOWER: dict[str, str] = {}
-for key in SUBJECTS.keys():
-    SUBJECTS_LOWER.update({key.lower(): key})
-
-
 DAYS = {"po": 0, "út": 1, "st": 2, "čt": 3, "pá": 4}
 
 DAYS_REVERSED: dict[int, str] = {}

--- a/src/bakabot/core/grades/grade.py
+++ b/src/bakabot/core/grades/grade.py
@@ -4,7 +4,7 @@ import datetime
 from typing import TYPE_CHECKING
 
 import disnake
-from constants import SUBJECTS
+from core.subjects.subjects_cache import SubjectsCache
 
 if TYPE_CHECKING:
     from core.grades.grades import Grades
@@ -15,7 +15,7 @@ class Grade:
         self,
         id: str,
         caption: str,
-        subject: str,
+        subjectName: str,
         weight: int,
         note: str,
         date: list[int],
@@ -24,7 +24,8 @@ class Grade:
     ):
         self.id = id
         self.caption = caption
-        self.subject = subject
+        self.subjectName = subjectName
+        """The full name of the subject. Short name has to be fetched from the subjects cache"""
         self.weight = weight
         self.note = note
         self.date = date
@@ -32,9 +33,9 @@ class Grade:
         self.gradeValue = gradeValue
 
     @staticmethod
-    def empty_grade(subject: str = "", weight: int = 1, gradeValue: float = 1):
+    def empty_grade(subjectName: str = "", weight: int = 1, gradeValue: float = 1):
         """Makes a Grade object with as little parameters as possible"""
-        return Grade("", "", subject, weight, "", [0, 0, 0], "", gradeValue)
+        return Grade("", "", subjectName, weight, "", [0, 0, 0], "", gradeValue)
 
     def grade_string(self):
         """Returns the `gradeValue` as a string. If the grade is a decimal number, adds a minus to it.
@@ -49,11 +50,16 @@ class Grade:
             return str(int(self.gradeValue))
 
     def show(self, grades: Grades):
+        """
+        Returns an embed with the grade information
+        - The full subject name is fetched from the subjects cache, if it's not found, fallbacks to the short name
+        """
+
         # Creation of the embed
         embed = disnake.Embed()
 
         # Subject
-        embed.set_author(name=SUBJECTS.get(self.subject))
+        embed.set_author(name=self.subjectName)
 
         # Grade
         embed.title = self.grade_string()
@@ -69,14 +75,17 @@ class Grade:
         embed.description = f"Váha: {self.weight}{captionsNotes}"
 
         # Current average
-        gradesFromSubject = grades.by_subject(self.subject)
+        maybeSubject = SubjectsCache.tryGetSubjectByName(self.subjectName)
+        subjectShortName = maybeSubject.shortName if maybeSubject else self.subjectName
+
+        gradesFromSubject = grades.by_subject_name(self.subjectName)
         subjectAverage = gradesFromSubject.average()
         if subjectAverage is None:
             # If there are no grades for the subject with a number grade
-            content = f"Průměr z {self.subject}: *nelze spočítat (žádné známky s číselným ohodnocením)*"
+            content = f"Průměr z {subjectShortName}: *nelze spočítat (žádné známky s číselným ohodnocením)*"
         else:
             # Normal average calculation
-            content = f"Průměr z {self.subject}: {subjectAverage}"
+            content = f"Průměr z {subjectShortName}: {subjectAverage}"
         embed.add_field(name="\u200b", value=content, inline=False)
 
         # Date

--- a/src/bakabot/core/grades/parse_grades.py
+++ b/src/bakabot/core/grades/parse_grades.py
@@ -2,7 +2,6 @@ import json
 import re
 
 from bs4 import BeautifulSoup
-from constants import SUBJECTS_REVERSED
 from core.grades.grade import Grade
 from core.grades.grades import Grades
 
@@ -39,17 +38,13 @@ def parseGradeJson(jsonGrade: dict[str, str]) -> Grade:
 
     caption = jsonGrade["caption"]
     id = jsonGrade["id"]
-    subject = jsonGrade["nazev"]
+    subjectName = jsonGrade["nazev"]
     weight = int(jsonGrade["vaha"])
     note = jsonGrade["poznamkakzobrazeni"]
     date = jsonGrade["datum"]
     gradeText = jsonGrade["MarkText"]
 
     cleanNote = note.replace(" <br>", "")
-
-    # Gets a short name for the subject
-    # TODO: reformat: move this somewhere else
-    shortSubject = SUBJECTS_REVERSED[subject]
 
     # Parses the date into list of [Year, Month, Day]
     # TODO: reformat: wth is this, use a datetime object not a list
@@ -68,4 +63,4 @@ def parseGradeJson(jsonGrade: dict[str, str]) -> Grade:
         else:
             gradeValue = int(gradeText)
 
-    return Grade(id, caption, shortSubject, weight, cleanNote, dateList, gradeText, gradeValue)
+    return Grade(id, caption, subjectName, weight, cleanNote, dateList, gradeText, gradeValue)

--- a/src/bakabot/core/reminder.py
+++ b/src/bakabot/core/reminder.py
@@ -4,6 +4,7 @@ from typing import Tuple
 import disnake
 from core.schedule.day import Day
 from core.schedule.schedule import Schedule
+from disnake.ext.commands import InteractionBot
 from utils.utils import from_sec_to_time, get_weekday_sec, getTextChannel, rand_rgb, read_db, write_db
 
 
@@ -67,7 +68,7 @@ class Reminder:
                         return lesson
 
     @staticmethod
-    async def reminder(client: disnake.Client, when: int):
+    async def reminder(client: InteractionBot, when: int):
         """Sends a reminder of the lesson to the discord channel"""
         await asyncio.sleep(when)
 
@@ -120,7 +121,7 @@ class Reminder:
         await asyncio.sleep(1)
 
     @staticmethod
-    async def remind_whole_day_schedule(day: Day, client: disnake.Client):
+    async def remind_whole_day_schedule(day: Day, client: InteractionBot):
         """Sends the whole day schedule"""
         # Creates the embed with today's schedule
         embed = disnake.Embed(color=disnake.Color.from_rgb(*rand_rgb()))
@@ -139,7 +140,7 @@ class Reminder:
         await getTextChannel(channelId, client).send(file=scheduleImg, embed=embed)
 
     @staticmethod
-    async def start_reminding(client: disnake.Client):
+    async def start_reminding(client: InteractionBot):
         """Starts an infinite loop for checking changes in the grades"""
         while True:
             when = Reminder.get_remind_time(Schedule.db_schedule(), get_weekday_sec())

--- a/src/bakabot/core/schedule/lesson.py
+++ b/src/bakabot/core/schedule/lesson.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from constants import SUBJECTS_REVERSED
+from core.subjects.subject import Subject
 from core.table import Table
 from utils.utils import read_db
 
@@ -9,7 +9,7 @@ class Lesson:
     def __init__(
         self,
         hour: int,
-        subject: Union[str, None] = None,
+        subject: Subject | None = None,
         classroom: Union[str, None] = None,
         teacher: Union[str, None] = None,
         changeInfo: Union[str, None] = None,
@@ -18,22 +18,9 @@ class Lesson:
         self.classroom = classroom
         self.teacher = teacher
         self.changeInfo = changeInfo
-        self.empty = None
         self.subject = subject
 
-    @property
-    def subject(self) -> str | None:
-        return self._subject
-
-    @subject.setter
-    def subject(self, name: str | None):
-        self._subject = name
-
-        self.subjectShort = SUBJECTS_REVERSED.get(name) if name else None
-        if self.subjectShort is None:
-            self.subjectShort = name
-
-        self.empty = not bool(name)
+        self.empty = subject is None
 
     def __str__(self) -> str:
         return f"Lesson(Hour: {self.hour}, Subject: {self.subject}, Classroom: {self.classroom}, Teacher: {self.teacher}, ChangeInfo: {self.changeInfo})"
@@ -73,7 +60,14 @@ class Lesson:
     ) -> Table.Cell:
         """Builds a `Table.Cell` object of the lesson."""
 
-        lessonCell = Table.Cell([Table.Cell.Item(self.subjectShort if shortName else self.subject)])
+        if self.subject is None:
+            raise ValueError("Cannot render an empty lesson")
+
+        lessonCell = Table.Cell([])
+
+        lessonNameText = self.subject.shortName if shortName else self.subject.fullName
+        lessonCell.items.append(Table.Cell.Item(lessonNameText))
+
         if showClassroom:
             lessonCell.items.append(Table.Cell.Item(self.classroom))
 

--- a/src/bakabot/core/subjects/subject.py
+++ b/src/bakabot/core/subjects/subject.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+
+class Subject:
+    def __init__(self, fullName: str, shortName: str | None):
+        self.fullName = fullName
+        """Full name of the subject. Always set. Extracted from both grades and schedule"""
+        self.shortName = shortName
+        """Short name of the subject. If not set, fallbacks to the full name. Extracted only from schedule"""
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Subject):
+            return False
+
+        return self.fullName == other.fullName and self.shortName == other.shortName
+
+    @property
+    def shortName(self) -> str:
+        """Short name of the subject. If not set, fallbacks to the full name"""
+
+        return self._shortName or self.fullName
+
+    @shortName.setter
+    def shortName(self, shortName: str | None):
+        self._shortName = shortName
+
+    @property
+    def hasShortName(self) -> bool:
+        """Returns True if the subject has a short name"""
+
+        return self._shortName is not None

--- a/src/bakabot/core/subjects/subjects_cache.py
+++ b/src/bakabot/core/subjects/subjects_cache.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import disnake
+from core.subjects.subject import Subject
+from core.subjects.utils import deduplicateSubjects
+from disnake.ext.commands import InteractionBot
+
+from bakabot.utils.utils import read_db, write_db
+
+
+class SubjectsCache:
+    """
+    Caches the subjects and provides methods to work with them
+    - A subject consists of both a full and a short name
+    - Full name is extracted from both grades and the schedule, short names are extracted only from the schedule and
+        thus we have to cache them
+    """
+
+    subjects: list[Subject] = []
+
+    @classmethod
+    def initialize(cls):
+        """Initializes the SubjectsCache"""
+
+        cls.subjects = cls._dbLoad()
+
+    @classmethod
+    def handleUpdateSubjects(cls, subjects: list[Subject]) -> bool:
+        """
+        Handles the update of new subjects.
+        - Subjects with updated full names are updated, subjects with new short names are added.
+        - Returns a boolean indicating whether any changes were made.
+        """
+
+        newSubjects = cls._getNewSubjects(subjects)
+        cls.subjects.extend(newSubjects)
+
+        toUpdateSubjects = cls._getToUpdateSubjects(subjects)
+        for subject in toUpdateSubjects:
+            cls._updateSubject(subject)
+
+        hasMadeChanges = any([newSubjects, toUpdateSubjects])
+        if hasMadeChanges:
+            cls._dbSave()
+
+        return hasMadeChanges
+
+    @classmethod
+    def getSubjectByName(cls, subjectName: str) -> Subject:
+        subject = cls.tryGetSubjectByName(subjectName)
+        if subject:
+            return subject
+
+        raise ValueError(f'No subject with the name "{subjectName}" found')
+
+    @classmethod
+    def tryGetSubjectByName(cls, subjectName: str) -> Subject | None:
+        """Tries to get the subject by its name. Returns None if not found."""
+
+        for subject in cls.subjects:
+            if subject.fullName == subjectName:
+                return subject
+
+    @classmethod
+    def updateCommandsWithSubjects(cls, client: InteractionBot):
+        """Updates the commands with the subjects"""
+
+        from bakabot.bot_commands.bot_commands import General
+
+        subjectChoices = cls.getSlashCommandSubjectChoices()
+
+        General.slashGradePrediction.options[0].choices = subjectChoices
+        General.slashGradesAverage.options[0].choices = subjectChoices
+
+        client.add_cog(General(client), override=True)
+
+    @classmethod
+    def getSlashCommandSubjectChoices(cls) -> list[disnake.OptionChoice]:
+        """Returns the most recent subjects to use for options in a slash command as options"""
+
+        choices: list[disnake.OptionChoice] = []
+
+        for subject in cls.subjects:
+            option = disnake.OptionChoice(name=subject.fullName, value=subject.fullName)
+            choices.append(option)
+
+        return choices
+
+    @classmethod
+    def _getNewSubjects(cls, subjects: list[Subject]) -> list[Subject]:
+        """Returns the new subjects from the list of subjects. Ignores duplicates."""
+
+        newSubjects = filter(
+            lambda subject: cls.tryGetSubjectByName(subject.fullName) is None,
+            subjects,
+        )
+
+        return deduplicateSubjects(list(newSubjects))
+
+    @classmethod
+    def _getToUpdateSubjects(cls, subjects: list[Subject]) -> list[Subject]:
+        """Returns the subjects that should be updated from the list of subjects. Ignores duplicates."""
+
+        toUpdateSubjects = filter(
+            lambda subject: cls._shouldUpdateSubject(subject),
+            subjects,
+        )
+
+        return deduplicateSubjects(list(toUpdateSubjects))
+
+    @classmethod
+    def _shouldUpdateSubject(cls, subject: Subject) -> bool:
+        """
+        Returns a boolean indicating whether the subject should be updated
+        - Subjects are matched by their full names, the short names are compared.
+        """
+
+        cachedSubject = cls.tryGetSubjectByName(subject.fullName)
+        if not cachedSubject:
+            return False
+
+        return cachedSubject.shortName != subject.shortName
+
+    @classmethod
+    def _updateSubject(cls, subject: Subject):
+        """Updates the subject in the cache"""
+
+        cachedSubject = cls.tryGetSubjectByName(subject.fullName)
+        if not cachedSubject:
+            return
+
+        cls.subjects.remove(cachedSubject)
+        cls.subjects.append(subject)
+
+    @staticmethod
+    def _dbLoad() -> list[Subject]:
+        """Loads the Subject objects from the database"""
+
+        subjects: list[Subject] | None = read_db("subjects")
+        if subjects is None:
+            raise Exception("Subjects database is empty")
+
+        return subjects
+
+    @classmethod
+    def _dbSave(cls):
+        """Saves the Subject objects to the database"""
+
+        write_db("subjects", cls.subjects)

--- a/src/bakabot/core/subjects/utils.py
+++ b/src/bakabot/core/subjects/utils.py
@@ -1,0 +1,13 @@
+from core.subjects.subject import Subject
+
+
+def deduplicateSubjects(subjects: list[Subject]) -> list[Subject]:
+    """Deduplicate the given list of subjects"""
+
+    deduplicatedSubjects: list[Subject] = []
+
+    for subject in subjects:
+        if subject not in deduplicatedSubjects:
+            deduplicatedSubjects.append(subject)
+
+    return deduplicatedSubjects

--- a/src/bakabot/message_timers.py
+++ b/src/bakabot/message_timers.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import disnake
+from disnake.ext.commands import InteractionBot
 from utils.utils import get_sec, getTextChannel, read_db, write_db
 
 # TODO: Reformat this file
@@ -58,7 +59,7 @@ class MessageTimers:
     async def delete_message(
         message: MessageUnionType,
         database: str,
-        client: disnake.Client,
+        client: InteractionBot,
         delay: int = 0,
     ):
         """Deletes the specified message from the chat after some delay"""
@@ -133,7 +134,7 @@ class MessageTimers:
         message: MessageUnionType,
         database: str,
         reaction: "EmojiInputType",
-        client: disnake.Client,
+        client: InteractionBot,
         delay: int = 0,
     ):
         """Deletes the specified reaction from the message after some delay"""
@@ -203,7 +204,7 @@ class MessageTimers:
                         return
 
     @staticmethod
-    async def query_messages(database: str, client: disnake.Client) -> list[disnake.Message]:
+    async def query_messages(database: str, client: InteractionBot) -> list[disnake.Message]:
         """Queries the messages from a specified database"""
 
         messagesTimers: list[MessageTimer] | None = read_db(database)
@@ -232,7 +233,7 @@ class MessageTimers:
         return foundMessages
 
     @staticmethod
-    async def query_messages_reactions(database: str, client: disnake.Client) -> list[disnake.Message]:
+    async def query_messages_reactions(database: str, client: InteractionBot) -> list[disnake.Message]:
         """Queries the reactions from a specified database into the current running client"""
 
         reactionTimers: list[ReactionTimer] | None = read_db(database)
@@ -269,7 +270,7 @@ class MessageTimers:
         return foundMessages
 
     @staticmethod
-    async def message_cache(client: disnake.Client, message: MessageUnionType):
+    async def message_cache(client: InteractionBot, message: MessageUnionType):
         """Adds the message into the clients custom cached messages"""
         if isinstance(message, LinkedMessage):
             try:

--- a/src/bakabot/utils/first_time_setup.py
+++ b/src/bakabot/utils/first_time_setup.py
@@ -1,8 +1,8 @@
 import os
 
-import disnake
 from core.grades.grades import Grades
-from core.schedule.schedule import Schedule
+from core.schedule.schedule import ChangeDetector, Schedule
+from disnake.ext.commands import InteractionBot
 from utils.utils import read_db, write_db
 
 
@@ -15,8 +15,9 @@ def setup_channel_error_message(channel: str):
     print(errorMessage)
 
 
-async def start(client: disnake.Client):
-    # First time startup
+async def start(client: InteractionBot) -> bool:
+    """Initializes the bot and returns a boolean value indicating whether the bot was initialized successfully"""
+
     if not os.path.isdir("./db"):
         os.mkdir("./db")
     if not os.path.isdir("./logs"):
@@ -40,30 +41,10 @@ async def start(client: disnake.Client):
         print("Restart the bot after you are done setting up the bot")
         return False
 
-    if not read_db("schedule1") or not read_db("schedule2"):
-        schedule1 = await Schedule.get_schedule(False, client)
-        schedule2 = await Schedule.get_schedule(True, client)
-        if schedule1 is None or schedule2 is None:
-            print("Bakalari's server is currently down. Wait until the server is back online and then restart the bot")
-            return None
-        else:
-            schedule1.db_save()
-            schedule2.db_save()
-    if not read_db("grades"):
-        grades = await Grades.getGrades(client)
-        if grades is None:
-            print("Bakalari's server is currently down. Wait until the server is back online and then restart the bot")
-            return None
-        else:
-            grades.db_save()
     if not read_db("gradesMessages"):
         write_db("gradesMessages", [])
     if not read_db("predictorMessages"):
         write_db("predictorMessages", [])
-    if not read_db("betts"):
-        write_db("betts", {})
-    if not read_db("bettMessages"):
-        write_db("bettMessages", [])
     if not read_db("responseChannels"):
         write_db("responseChannels", {})
     if read_db("showDay") == None:
@@ -72,5 +53,26 @@ async def start(client: disnake.Client):
         write_db("showClassroom", False)
     if read_db("reminderShort") == None:
         write_db("reminderShort", False)
+    if read_db("subjects") == None:
+        write_db("subjects", [])
+
+    if not read_db("schedule1") or not read_db("schedule2"):
+        schedule1 = await Schedule.get_schedule(False, client)
+        schedule2 = await Schedule.get_schedule(True, client)
+        if schedule1 is None or schedule2 is None:
+            print("Bakalari's server is currently down. Wait until the server is back online and then restart the bot")
+            return False
+        else:
+            ChangeDetector.handle_update_subjects_cache((schedule1, schedule2), client)
+            schedule1.db_save()
+            schedule2.db_save()
+    if not read_db("grades"):
+        grades = await Grades.getGrades(client)
+        if grades is None:
+            print("Bakalari's server is currently down. Wait until the server is back online and then restart the bot")
+            return False
+        else:
+            Grades.handle_update_subjects_cache(grades.grades, client)
+            grades.db_save()
 
     return True

--- a/src/bakabot/utils/utils.py
+++ b/src/bakabot/utils/utils.py
@@ -8,6 +8,7 @@ import aiohttp
 import disnake
 import dotenv
 import pytz
+from disnake.ext.commands import InteractionBot
 
 
 # Reads a from the database by key. Returns none if the key doesn't exist
@@ -39,7 +40,7 @@ def os_environ(key: str):
         return os.environ[key]
 
 
-def getTextChannel(channelId: int, client: disnake.Client):
+def getTextChannel(channelId: int, client: InteractionBot):
     """Gets the text channel by the given id. Throws an error if the channel doesn't exist or is not a text channel"""
     channel = client.get_channel(channelId)
     if not isinstance(channel, disnake.TextChannel):
@@ -49,7 +50,7 @@ def getTextChannel(channelId: int, client: disnake.Client):
 
 
 # Logs into the server and returns the login session
-async def login(client: disnake.Client):
+async def login(client: InteractionBot):
     username = os_environ("bakalariUsername")
     password = os_environ("bakalariPassword")
 
@@ -73,7 +74,7 @@ async def login(client: disnake.Client):
         return session
 
 
-async def request(session: aiohttp.ClientSession, url: str, get: bool, client: disnake.Client):
+async def request(session: aiohttp.ClientSession, url: str, get: bool, client: InteractionBot):
     try:
         if get:
             response = await session.get(url, timeout=25)
@@ -92,7 +93,7 @@ async def request(session: aiohttp.ClientSession, url: str, get: bool, client: d
         return None
 
 
-async def status(online: bool, client: disnake.Client):
+async def status(online: bool, client: InteractionBot):
     """Send's the current status of the bakalari server to discord"""
     lastStatus = read_db("lastStatus")
 
@@ -190,7 +191,7 @@ def from_sec_to_time(sec: int):
     return output
 
 
-async def fetch_message(message_channel: int, message_id: int, client: disnake.Client):
+async def fetch_message(message_channel: int, message_id: int, client: InteractionBot):
     try:
         return await getTextChannel(message_channel, client).fetch_message(message_id)
     except:

--- a/tests/subjects/test_subjects_cache.py
+++ b/tests/subjects/test_subjects_cache.py
@@ -1,0 +1,122 @@
+import disnake
+import pytest
+from core.subjects.subject import Subject
+from core.subjects.subjects_cache import SubjectsCache
+from pytest_mock import MockerFixture
+
+
+def test_initialize(mocker: MockerFixture):
+    """Should initialize from the database"""
+
+    spy = mocker.spy(SubjectsCache, "_dbLoad")
+    spy.attach_mock(mocker.Mock(), "_dbLoad")
+    SubjectsCache.initialize()
+
+    spy.assert_called_once()
+
+
+def test_getSubjectByName():
+    """Should return the subject by its name and raise an error if not found"""
+
+    SubjectsCache.subjects = [Subject("subject1", None)]
+
+    assert SubjectsCache.getSubjectByName("subject1").fullName == "subject1"
+
+    pytest.raises(ValueError, SubjectsCache.getSubjectByName, "subject2")
+
+
+def test_tryGetSubjectByName():
+    """Should return the subject by its name and None if not found"""
+
+    SubjectsCache.subjects = [Subject("subject1", None)]
+
+    firstSubject = SubjectsCache.tryGetSubjectByName("subject1")
+    assert isinstance(firstSubject, Subject)
+    assert firstSubject.fullName == "subject1"
+
+    assert SubjectsCache.tryGetSubjectByName("subject2") is None
+
+
+class Test_HandleUpdateSubjects:
+    def test_ignore_existing_subjects(self, mocker: MockerFixture):
+        """Should ignore already existing subjects"""
+
+        SubjectsCache.subjects = [Subject("subject1", None)]
+
+        spy = mocker.spy(SubjectsCache, "_dbSave")
+        spy.attach_mock(mocker.Mock(), "_dbSave")
+        changed = SubjectsCache.handleUpdateSubjects([Subject("subject1", None)])
+
+        assert changed == False
+        assert SubjectsCache.subjects == [Subject("subject1", None)]
+        spy.assert_not_called()
+
+    def test_add_new_subjects(self, mocker: MockerFixture):
+        """Should add new subjects"""
+
+        SubjectsCache.subjects = [Subject("subject1", None)]
+
+        spy = mocker.spy(SubjectsCache, "_dbSave")
+        spy.attach_mock(mocker.Mock(), "_dbSave")
+        changed = SubjectsCache.handleUpdateSubjects([Subject("subject2", None)])
+
+        assert changed == True
+        assert SubjectsCache.subjects == [
+            Subject("subject1", None),
+            Subject("subject2", None),
+        ]
+        spy.assert_called_once()
+
+    def test_update_subjects(self, mocker: MockerFixture):
+        """Should update subjects"""
+
+        SubjectsCache.subjects = [Subject("subject1", None)]
+
+        spy = mocker.spy(SubjectsCache, "_dbSave")
+        spy.attach_mock(mocker.Mock(), "_dbSave")
+        changed = SubjectsCache.handleUpdateSubjects([Subject("subject1", "short1")])
+
+        assert changed == True
+        assert SubjectsCache.subjects == [Subject("subject1", "short1")]
+        spy.assert_called_once()
+
+    def test_multiple_changes(self, mocker: MockerFixture):
+        """Should handle ignoring, adding and updating deduplicating subjects"""
+
+        SubjectsCache.subjects = [Subject("subject1", None), Subject("subject2", None)]
+
+        spy = mocker.spy(SubjectsCache, "_dbSave")
+        spy.attach_mock(mocker.Mock(), "_dbSave")
+        changed = SubjectsCache.handleUpdateSubjects(
+            [
+                Subject("subject1", None),
+                Subject("subject2", None),
+                Subject("subject2", None),
+                Subject("subject3", "short3"),
+                Subject("subject1", "short1"),
+                Subject("subject1", "short1"),
+            ]
+        )
+
+        assert changed == True
+        assert len(SubjectsCache.subjects) == 3
+        assert Subject("subject1", "short1") in SubjectsCache.subjects
+        assert Subject("subject2", None) in SubjectsCache.subjects
+        assert Subject("subject3", "short3") in SubjectsCache.subjects
+        spy.assert_called_once()
+
+
+def test_getSlashCommandSubjectChoices():
+    """Should return the subject choices for the slash commands"""
+
+    SubjectsCache.subjects = [
+        Subject("subject1", "short1"),
+        Subject("subject2", "short2"),
+    ]
+
+    choices = SubjectsCache.getSlashCommandSubjectChoices()
+
+    assert choices == [
+        disnake.OptionChoice(name="subject1", value="subject1"),
+        disnake.OptionChoice(name="subject2", value="subject2"),
+    ]

--- a/tests/subjects/test_utils.py
+++ b/tests/subjects/test_utils.py
@@ -1,0 +1,18 @@
+from core.subjects.subject import Subject
+from core.subjects.utils import deduplicateSubjects
+
+
+def test_deduplicateSubjects():
+    """Should deduplicate subjects"""
+
+    subjects = [
+        Subject("subject1", None),
+        Subject("subject2", None),
+        Subject("subject1", None),
+    ]
+
+    deduplicatedSubjects = deduplicateSubjects(subjects)
+
+    assert len(deduplicatedSubjects) == 2
+    assert Subject("subject1", None) in deduplicatedSubjects
+    assert Subject("subject2", None) in deduplicatedSubjects


### PR DESCRIPTION
### Implements a subject names cache that stores subjects extracted from grades and schedules.

---
This resolves the need to have the subjects hard-coded as constants. They are now automatically extracted from schedules and grades and are stored into a cache.

Hi @Vojtak42, if you have time and will, would please look at this PR? It's pretty big, so it's pretty hard for a review, but I will comment out the most important changes :) Many thanks!
I can't currently add you as a reviewer since you are not a collaborator in this repo. I have sent you an invite ;)

---
Context:
- Subjects have a full and a short name
  - Full name can be extracted from both grades and schedule
  - Short name can only be extracted from schedule
  - As such a need to cache subjects between the two methods of scraping arises, so we can display the short name where we want

Ideally we would only extract this from the schedule then, but an edge case where there would be a grade for a subject that was not yet seen in the schedule would break it. So we have to scrape it from both places.
If a short name cannot be scraped, the full name is used as a fallback.

